### PR TITLE
Allow multiple var_file fix #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Concourse CI resource to build new [Amazon Machine Images (AMI) via Packer](ht
 
 #### Parameters
 - `template`: *Required.* The path to the packer template.
-- `var_file`: *Required.* The path to a [external JSON variable file](https://www.packer.io/docs/templates/user-variables.html).
+- `var_file`: *Required.* The path or list of paths to a [external JSON variable file](https://www.packer.io/docs/templates/user-variables.html).
 
 All other parameters will be passed through to packer as variables.
 
@@ -44,5 +44,7 @@ jobs:
   - put: build-ami
     params:
       template: packer_template.json
-      var_file: secrets.json
+      var_file:
+         - secrets.json
+         - foo.json
   ```

--- a/bin/out
+++ b/bin/out
@@ -20,14 +20,18 @@ elif [ ! -f "$SRC/$TEMPLATE" ]; then
   exit 1
 fi
 
+
 ARGS=""
-VAR_FILE=$(jq -r '.params.var_file // empty' /tmp/input)
-if [ ! -f "$SRC/$VAR_FILE" ]; then
-  echo "var_file $SRC/$VAR_FILE does not exist" >&2
-  exit 1
-else
-  ARGS="-var-file=$SRC/$VAR_FILE"
-fi
+FILES=$(jq -r '.params.var_file // empty | if type =="array" then .[] else . end' /tmp/input)
+
+for FILE in $FILES;do
+  if [ ! -f "$SRC/$FILE" ]; then
+    echo "var_file $SRC/$FILE does not exist" >&2
+    exit 1
+  else
+    ARGS="${ARGS} -var-file=$SRC/$FILE"
+  fi
+done
 
 jq '.params|del(.template,.var_file) // empty' /tmp/input > /tmp/vars.json
 


### PR DESCRIPTION
Packer allow to have multiple --var-file. The resource concourse is now
able to handle a list of var_file.

I am not really familiar with jq, so don't hesitate if you have any suggestions ;)