### PR TITLE
make aws credentials optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A Concourse CI resource to build new [Amazon Machine Images (AMI) via Packer](ht
 
 ## Source Configuration
 
-- `aws_access_key_id`: *Required.* Your AWS access key ID.
+- `aws_access_key_id`: *Optional.* Your AWS access key ID.
 
-- `aws_secret_access_key`: *Required.* Your AWS secret access key.
+- `aws_secret_access_key`: *Optional.* Your AWS secret access key.
 
 - `region`: *Required.* The AWS region to search for AMIs.
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A Concourse CI resource to build new [Amazon Machine Images (AMI) via Packer](ht
 
 ## Source Configuration
 
-- `aws_access_key_id`: *Optional.* Your AWS access key ID.
+- `aws_access_key_id`: Your AWS access key ID.
 
-- `aws_secret_access_key`: *Optional.* Your AWS secret access key.
+- `aws_secret_access_key`: Your AWS secret access key.
 
 - `region`: *Required.* The AWS region to search for AMIs.
 
+If `aws_access_key_id` and `aws_secret_access_key` are not provided [packer will use credentials provided by the workers's IAM profile, if it has one](https://www.packer.io/docs/builders/amazon.html#using-an-iam-instance-profile).
 
 ## Behaviour
 

--- a/bin/out
+++ b/bin/out
@@ -10,6 +10,16 @@ export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' < /tmp/inp
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' < /tmp/input)
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' < /tmp/input)
 
+# remove any empty credentials vars so the AWS client will try instance profiles
+# https://www.packer.io/docs/builders/amazon.html#using-an-iam-instance-profile
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+  unset AWS_ACCESS_KEY_ID
+fi
+
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  unset AWS_SECRET_ACCESS_KEY
+fi
+
 TEMPLATE=$(jq -r '.params.template // empty' /tmp/input)
 if [ -z "$TEMPLATE" ]; then
   echo "template not passed in params:" >&2


### PR DESCRIPTION
@jdub This PR doesn't set empty variables if AWS credentials aren't provided.  This allows for instance profiles to be used.

