### PR TITLE
Add aws_session_token variable to support temporary AWS credentials.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ A Concourse CI resource to build new [Amazon Machine Images (AMI) via Packer](ht
 
 - `aws_secret_access_key`: Your AWS secret access key.
 
+- `aws_session_token`: Your AWS session token (Optional).
+
 - `region`: *Required.* The AWS region to search for AMIs.
 
-If `aws_access_key_id` and `aws_secret_access_key` are not provided [packer will use credentials provided by the worker's IAM profile, if it has one](https://www.packer.io/docs/builders/amazon.html#using-an-iam-instance-profile).
+If `aws_access_key_id`, `aws_secret_access_key` and `aws_session_token` are not provided [packer will use credentials provided by the worker's IAM profile, if it has one](https://www.packer.io/docs/builders/amazon.html#using-an-iam-instance-profile).
 
 ## Behaviour
 
@@ -37,6 +39,7 @@ resources:
   source:
     aws_access_key_id: "..."
     aws_secret_access_key: "..."
+    aws_session_token: "..."
     region: ap-southeast-2
 
 jobs:

--- a/bin/out
+++ b/bin/out
@@ -8,6 +8,7 @@ SRC=$1
 
 export AWS_ACCESS_KEY_ID=$(jq -r '.source.aws_access_key_id // empty' < /tmp/input)
 export AWS_SECRET_ACCESS_KEY=$(jq -r '.source.aws_secret_access_key // empty' < /tmp/input)
+export AWS_SESSION_TOKEN=$(jq -r '.source.aws_session_token // empty' < /tmp/input)
 export AWS_DEFAULT_REGION=$(jq -r '.source.region // empty' < /tmp/input)
 
 # remove any empty credentials vars so the AWS client will try instance profiles
@@ -18,6 +19,10 @@ fi
 
 if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
   unset AWS_SECRET_ACCESS_KEY
+fi
+
+if [ -z "$AWS_SESSION_TOKEN" ]; then
+    unset AWS_SESSION_TOKEN
 fi
 
 TEMPLATE=$(jq -r '.params.template // empty' /tmp/input)


### PR DESCRIPTION
When using temporary AWS credentials (such as credentials from an assumed role), the AWS CLI requires that AWS_SESSION_TOKEN is set in order to validate the credentials. This PR adds the aws_session_token variable.

Also added a PR for session token in [jdub/ami-resource](https://github.com/jdub/ami-resource/pull/6)